### PR TITLE
Fixes #39 - NotFoundResult

### DIFF
--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
@@ -230,7 +230,6 @@ namespace Blazored.Typeahead
         protected bool ShowNotFound()
         {
             return IsShowingSuggestions &&
-                   HasValidSearch &&
                    !IsSearchingOrDebouncing &&
                    !Suggestions.Any();
         }

--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
@@ -223,8 +223,6 @@ namespace Blazored.Typeahead
                    Suggestions.Any();
         }
 
-        private bool HasValidSearch => !string.IsNullOrWhiteSpace(SearchText) && SearchText.Length >= MinimumLength;
-
         private bool IsSearchingOrDebouncing => IsSearching || _debounceTimer.Enabled;
 
         protected bool ShowNotFound()

--- a/src/Blazored.Typeahead/Forms/BlazoredTypeaheadInput.razor.cs
+++ b/src/Blazored.Typeahead/Forms/BlazoredTypeaheadInput.razor.cs
@@ -226,14 +226,11 @@ namespace Blazored.Typeahead.Forms
                    Suggestions.Any();
         }
 
-        private bool HasValidSearch => !string.IsNullOrWhiteSpace(SearchText) && SearchText.Length >= MinimumLength;
-
         private bool IsSearchingOrDebouncing => IsSearching || _debounceTimer.Enabled;
 
         protected bool ShowNotFound()
         {
             return IsShowingSuggestions &&
-                   HasValidSearch &&
                    !IsSearchingOrDebouncing &&
                    !Suggestions.Any();
         }


### PR DESCRIPTION
When you click the caret to trigger the `SearchMethod` without a `searchterm` and there were no results, the component did not show the `NotFoundResult` due to the `HasValidSearch` Method. This PR handles that issue.