### PR TITLE
Fixed bug when control is disabled and bound to null value

### DIFF
--- a/samples/BlazorClientSide/Pages/Index.razor
+++ b/samples/BlazorClientSide/Pages/Index.razor
@@ -73,6 +73,24 @@
 
 <hr />
 
+<h1>Blazored Typeahead - Disabled (Null Value)</h1>
+
+<BlazoredTypeahead SearchMethod="@GetPeopleLocal"
+                   @bind-Value="@SelectedPersonNull"
+                   Disabled="IsDisabled"
+                   placeholder="Search by first name...">
+    <SelectedTemplate Context="person">
+        @person.Firstname
+    </SelectedTemplate>
+    <ResultTemplate Context="person">
+        @person.Firstname @person.Lastname
+    </ResultTemplate>
+</BlazoredTypeahead>
+
+<button class="btn btn-primary" style="margin-top: 20px;" @onclick="@(() => IsDisabled = !IsDisabled)">@(IsDisabled ? "Enable" : "Disable")</button>
+
+<hr />
+
 <h1>Blazored Typeahead - Binding to different type</h1>
 
 <BlazoredTypeahead SearchMethod="GetPeopleLocal"
@@ -164,6 +182,7 @@
     private List<Person> People = new List<Person>();
 
     private Person SelectedPerson;
+    private Person SelectedPersonNull;
     private int? SelectedPersonId;
     private IList<Person> SelectedPeople;
     private FormExample FormModel = new FormExample();

--- a/samples/BlazorServerSide/Pages/Index.razor
+++ b/samples/BlazorServerSide/Pages/Index.razor
@@ -73,6 +73,24 @@
 
 <hr />
 
+<h1>Blazored Typeahead - Disabled (Null Value)</h1>
+
+<BlazoredTypeahead SearchMethod="@GetPeopleLocal"
+                   @bind-Value="@SelectedPersonNull"
+                   Disabled="IsDisabled"
+                   placeholder="Search by first name...">
+    <SelectedTemplate Context="person">
+        @person.Firstname
+    </SelectedTemplate>
+    <ResultTemplate Context="person">
+        @person.Firstname @person.Lastname
+    </ResultTemplate>
+</BlazoredTypeahead>
+
+<button class="btn btn-primary" style="margin-top: 20px;" @onclick="@(() => IsDisabled = !IsDisabled)">@(IsDisabled ? "Enable" : "Disable")</button>
+
+<hr />
+
 <h1>Blazored Typeahead - Binding to different type</h1>
 
 <BlazoredTypeahead SearchMethod="GetPeopleLocal"
@@ -135,6 +153,7 @@
     private List<Person> People = new List<Person>();
 
     private Person SelectedPerson;
+    private Person SelectedPersonNull;
     private int? SelectedPersonId;
     private IList<Person> SelectedPeople;
     private FormExample FormModel = new FormExample();

--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor
@@ -27,9 +27,12 @@
                 }
                 else
                 {
-                    <div class="blazored-typeahead__input-mask" tabindex="0">
-                        @SelectedTemplate(Value)
-                    </div>
+                    if (Value != null)
+                    {
+                        <div class="blazored-typeahead__input-mask" tabindex="0">
+                            @SelectedTemplate(Value)
+                        </div>
+                    }
                 }
             </div>
             <div class="blazored-typeahead__input-icon blazored-typeahead__input-icon--disabled">


### PR DESCRIPTION
When the control was bound to a `null` value and it was also disabled, it would cause an exception as it tried to load the `SelectedTemplate` passing the `null` value. 

This PR adds a `null` check to stop this happening.