### PR TITLE
Fix #91 OnFocus be able to type

### DIFF
--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
@@ -213,17 +213,25 @@ namespace Blazored.Typeahead
         {
             switch (args.Key)
             {
+                case "Tab":
+                    break; // Don't do anything on tab.
                 case "Enter":
-                    IsShowingMask = false;
-                    await Task.Delay(250); // Possible race condition here.
-                    await Interop.Focus(JSRuntime, _searchInput);
-                    break;
                 case "Backspace":
                 case "Delete":
+                case "Escape":
                     await HandleClear();
                     break;
                 default:
                     break;
+            }
+
+            // You can only start searching if it's not a special key (Tab, Enter, Escape, ...)
+            if(args.Key.Length == 1)
+            {
+                IsShowingMask = false;
+                await Task.Delay(250); // Possible race condition here.
+                await Interop.Focus(JSRuntime, _searchInput);
+                SearchText = args.Key;
             }
         }
 
@@ -373,7 +381,7 @@ namespace Blazored.Typeahead
         private bool ShouldShowSuggestions()
         {
             return IsShowingSuggestions &&
-                   Suggestions.Any();
+                   Suggestions.Any() && !IsSearchingOrDebouncing;
         }
 
         private void MoveSelection(int count)

--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
@@ -332,6 +332,7 @@ namespace Blazored.Typeahead
 
             IsSearching = false;
             IsShowingSuggestions = true;
+            SelectedIndex = 0;
             await InvokeAsync(StateHasChanged);
         }
 


### PR DESCRIPTION
When a value is already selected and you focus the control by using tab you can now directly start typing without pressing Enter or Delete.

![Example](https://i.imgur.com/aKvbBIp.gif)