### PR TITLE
Fix JS "element is null" error when disabling component right after selection.

### DIFF
--- a/src/Blazored.Typeahead/wwwroot/blazored-typeahead.js
+++ b/src/Blazored.Typeahead/wwwroot/blazored-typeahead.js
@@ -1,7 +1,7 @@
 window.blazoredTypeahead = {
     assemblyname: "Blazored.Typeahead",
     setFocus: (element) => {
-        element.focus();
+        if (element) element.focus();
     },
     // No need to remove the event listeners later, the browser will clean this up automagically.
     addKeyDownEventListener: (element) => {


### PR DESCRIPTION
When changing Disabled to false inside the ValueChanged callback, it throws an "element is null" error on the JS 'setFocus' function.

To fix that, I added a small check in the 'element' parameter.