### PR TITLE
Remove last entry from multi-select by pressing backspace

### DIFF
--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
@@ -264,6 +264,10 @@ namespace Blazored.Typeahead
             {
                 await SelectResult(Suggestions[SelectedIndex]);
             }
+            else if (IsMultiselect && args.Key == "Backspace")
+            {
+                await RemoveValue(Values.Last());
+            }
         }
 
         private async Task HandleInputFocus()


### PR DESCRIPTION
This isn't everything that was suggested, it adds the ability to press backspace and remove the last item added.

Resolves #125