### PR TITLE
Update blazored-typeahead.js

### DIFF
--- a/src/Blazored.Typeahead/wwwroot/blazored-typeahead.js
+++ b/src/Blazored.Typeahead/wwwroot/blazored-typeahead.js
@@ -3,7 +3,7 @@
 window.blazoredTypeahead = {
     assemblyname: "Blazored.Typeahead",
     setFocus: function (element) {
-        if (element) element.focus();
+        if (element && element.focus) element.focus();
     },
     // No need to remove the event listeners later, the browser will clean this up automagically.
     addKeyDownEventListener: function (element) {


### PR DESCRIPTION
Resolves #122

I received the error below. This should solve that error.

> Error: Microsoft.JSInterop.JSException: element.focus is not a function
TypeError: element.focus is not a function
    at Object.setFocus (https://localhost:5001/_content/Blazored.Typeahead/blazored-typeahead.js:6:30)
    at https://localhost:5001/_framework/blazor.server.js:8:31619
    at new Promise (<anonymous>)
    at e.beginInvokeJSFromDotNet (https://localhost:5001/_framework/blazor.server.js:8:31587)
    at https://localhost:5001/_framework/blazor.server.js:1:20052
    at Array.forEach (<anonymous>)
    at e.invokeClientMethod (https://localhost:5001/_framework/blazor.server.js:1:20022)
    at e.processIncomingData (https://localhost:5001/_framework/blazor.server.js:1:18006)
    at e.connection.onreceive (https://localhost:5001/_framework/blazor.server.js:1:11091)
    at WebSocket.i.onmessage (https://localhost:5001/_framework/blazor.server.js:1:39007)
   at Microsoft.JSInterop.JSRuntime.InvokeWithDefaultCancellation[T](String identifier, Object[] args)
   at Blazored.Typeahead.BlazoredTypeahead`2.SelectResult(TItem item)
   at Microsoft.AspNetCore.Components.ComponentBase.CallStateHasChangedOnAsyncCompletion(Task task)
   at Microsoft.AspNetCore.Components.RenderTree.Renderer.GetErrorHandledTask(Task taskToHandle)