### PR TITLE
Multiselect null error fix

### DIFF
--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
@@ -264,8 +264,8 @@ namespace Blazored.Typeahead
             {
                 await SelectResult(Suggestions[SelectedIndex]);
             }
-            else if (IsMultiselect && args.Key == "Backspace")
-            {
+            else if (IsMultiselect && args.Key == "Backspace" && (Values?.Any() ?? false) && SearchText.Length == 0)
+            {   
                 await RemoveValue(Values.Last());
             }
         }


### PR DESCRIPTION
Fixed an error where pressing backspace immediatly deletes an item (even is a search term is present) and prevented null error when there are no items selected.

Partial fix for #174 
(if there is one character in the text box and backspace is pressed, the previous entry is still deleted. This is because HandleKeyUp is called after the input is deleted)