### PR TITLE
MultiSelect fix

### DIFF
--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor
@@ -79,7 +79,6 @@
                            @onkeyup="HandleKeyup"
                            @onkeyup:stopPropagation="@StopPropagation"
                            @onkeyup:preventDefault="@PreventDefault"
-                           @onblur="ResetControl"
                            @onfocus="HandleInputFocus"
                            autocomplete="off"
                            @attributes="AdditionalAttributes"

--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor
@@ -76,6 +76,7 @@
                     <input @ref="_searchInput"
                            @bind-value="SearchText"
                            @bind-value:event="oninput"
+                           @onkeydown="HandleKeydown"
                            @onkeyup="HandleKeyup"
                            @onkeyup:stopPropagation="@StopPropagation"
                            @onkeyup:preventDefault="@PreventDefault"

--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
@@ -136,7 +136,7 @@ namespace Blazored.Typeahead
 
         protected override void OnParametersSet()
         {
-            Initialize();
+            //Initialize();
         }
 
         private void Initialize()
@@ -434,15 +434,7 @@ namespace Blazored.Typeahead
 
             _editContext?.NotifyFieldChanged(_fieldIdentifier);
 
-            if (IsMultiselect)
-            {
-                await Interop.Focus(JSRuntime, _searchInput);
-            }
-            else
-            {
-                await Task.Delay(250);
-                await Interop.Focus(JSRuntime, _mask);
-            }
+            Initialize();
         }
 
         private bool ShouldShowHelpTemplate()
@@ -505,7 +497,7 @@ namespace Blazored.Typeahead
 
         public async Task Focus()
         {
-            await Interop.Focus(JSRuntime, _searchInput);
+            await HandleClickOnMask(); // Interop.Focus(JSRuntime, _searchInput);
         }
     }
 }

--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
@@ -185,6 +185,7 @@ namespace Blazored.Typeahead
 
             await Task.Delay(250); // Possible race condition here.
             await Interop.Focus(JSRuntime, _searchInput);
+            await HookOutsideClick();
         }
 
         private async Task HandleKeyUpOnShowDropDown(KeyboardEventArgs args)

--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
@@ -240,6 +240,16 @@ namespace Blazored.Typeahead
                 SearchText = args.Key;
             }
         }
+        private async Task HandleKeydown(KeyboardEventArgs args)
+        {
+
+            Console.WriteLine("key: " + args.Key);
+            if (args.Key == "Tab")
+            {
+                await ResetControl();
+            }
+            
+        }
 
         private async Task HandleKeyup(KeyboardEventArgs args)
         {

--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
@@ -350,6 +350,10 @@ namespace Blazored.Typeahead
                 IsSearching = false;
                 await InvokeAsync(StateHasChanged);
             }
+            else
+            {
+                await ResetControlBlur();
+            }
             await HookOutsideClick();
         }
 


### PR DESCRIPTION
Removed "ResetControl" on blur for MultiSelect
Added potential way to allow MultiSelect to highlight multiple options without closing the list

Issues raised in https://github.com/Blazored/Typeahead/issues/199

The main fix is removing the ResetControl from line 82 BlazoredTypeahead.razor  

I've also added a possible way to multi-select the list by moving the Values update to the reset method but not sure if it's the best way. My main worry is around removing items at line 404. Not sure if bindings would update then or wait for the reset method. 