### PR TITLE
Fix crash when value is null

### DIFF
--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor
@@ -89,7 +89,7 @@
             }
             else
             {
-                if (IsShowingMask)
+                if (IsShowingMask && Value != null)
                 {
                     <div class="blazored-typeahead__input-mask-wrapper">
                         <div class="blazored-typeahead__input-mask" @onclick="HandleClickOnMask" @onkeyup="HandleKeyUpOnMask" tabindex="0" @ref="_mask">


### PR DESCRIPTION
When my property that is tied to `@bind-Value` does some more work than just assigning the value, app crashes occasionally when item is selected. This fixes it.

This fix is for `Value` property. I see that `Values` property already has the same checks in place.