### PR TITLE
Added possibility to add an item when no item is found

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ of `Person` but when a `Person` was selected you wanted the control to bind to a
 a `ConvertMethod` The convert method will be invoked by the control when a selection is made and will be passed the type selected. The method will need to handle the conversion
 and return the new type.
 
+If you want to allow adding an item based on the search when no items have been found, you can achieve this by providing the `AddItemOnEmptyResultMethod` as a parameter.
+This method will make the `NotFoundTemplate` selectable the same way a item would normally be, and will be invoked when the user selects the `NotFoundTemplate`.
+This method passes the `SearchText` and expects a new item to be returned.
 
 ### Local Data Example
 ```cs

--- a/samples/BlazorServer/Pages/Index.razor
+++ b/samples/BlazorServer/Pages/Index.razor
@@ -150,8 +150,44 @@
     {
         <p>@person.Firstname @person.Lastname</p>
     }
+    <hr />
 }
 
+<h1>Blazored Typeahead - Multi-select - Adding items on empty search result</h1>
+
+<BlazoredTypeahead SearchMethod="GetPeopleLocal"
+                   @bind-Values="SelectedPeopleWithNotFoundTemplate"
+                   Disabled="IsDisabledMulti"
+                   EnableDropDown="true"
+                   MinimumLength="2"
+                   AddItemOnEmptyResultMethod="ItemAddedMethod"
+                   placeholder="Search by first name...">
+    <SelectedTemplate Context="person">
+        @person.Firstname
+    </SelectedTemplate>
+    <HelpTemplate>
+        Please enter a minimum of 2 characters to perform a search.
+    </HelpTemplate>
+    <NotFoundTemplate Context="searchText">
+        Add "@searchText" as a new user <br />
+        The newly added user will be selected after being added.
+    </NotFoundTemplate>
+    <ResultTemplate Context="person">
+        @person.Firstname @person.Lastname (Id: @person.Id)
+    </ResultTemplate>
+</BlazoredTypeahead>
+<button class="btn btn-primary" style="margin-top: 20px;" @onclick="@(() => IsDisabledMulti = !IsDisabledMulti)">@(IsDisabledMulti ? "Enable" : "Disable")</button>
+<hr />
+
+@if (SelectedPeopleWithNotFoundTemplate != null)
+{
+    <p>Selected People:</p>
+    foreach (var person in SelectedPeopleWithNotFoundTemplate)
+    {
+        <p>@person.Firstname @person.Lastname</p>
+    }
+    <hr />
+}
 
 @code {
 
@@ -164,6 +200,7 @@
     private Person SelectedPersonNull;
     private int? SelectedPersonId;
     private IList<Person> SelectedPeople;
+    private IList<Person> SelectedPeopleWithNotFoundTemplate;
     private FormExample FormModel = new FormExample();
 
     protected override void OnInitialized()
@@ -242,4 +279,14 @@
     {
         return People.FirstOrDefault(p => p.Id == id);
     }
+
+    private readonly Random _random = new Random();
+    private Task<Person> ItemAddedMethod(string searchText)
+    {
+        var randomPerson = People[_random.Next(People.Count - 1)];
+        var newPerson = new Person(_random.Next(1000, int.MaxValue), searchText, randomPerson.Lastname, _random.Next(10, 70), randomPerson.Location);
+        People.Add(newPerson);
+        return Task.FromResult(newPerson);
+    }
+
 }

--- a/samples/BlazorWebAssembly/Pages/Index.razor
+++ b/samples/BlazorWebAssembly/Pages/Index.razor
@@ -146,9 +146,44 @@
     {
         <p>@person.Firstname @person.Lastname</p>
     }
+    <hr />
 }
 
+<h1>Blazored Typeahead - Multi-select - Adding items on empty search result</h1>
+
+<BlazoredTypeahead SearchMethod="GetPeopleLocal"
+                   @bind-Values="SelectedPeopleWithNotFoundTemplate"
+                   Disabled="IsDisabledMulti"
+                   EnableDropDown="true"
+                   MinimumLength="2"
+                   AddItemOnEmptyResultMethod="ItemAddedMethod"
+                   placeholder="Search by first name...">
+    <SelectedTemplate Context="person">
+        @person.Firstname
+    </SelectedTemplate>
+    <HelpTemplate>
+        Please enter a minimum of 2 characters to perform a search.
+    </HelpTemplate>
+    <NotFoundTemplate Context="searchText">
+        Add "@searchText" as a new user <br />
+        The newly added user will be selected after being added.
+    </NotFoundTemplate>
+    <ResultTemplate Context="person">
+        @person.Firstname @person.Lastname (Id: @person.Id)
+    </ResultTemplate>
+</BlazoredTypeahead>
+<button class="btn btn-primary" style="margin-top: 20px;" @onclick="@(() => IsDisabledMulti = !IsDisabledMulti)">@(IsDisabledMulti ? "Enable" : "Disable")</button>
 <hr />
+
+@if (SelectedPeopleWithNotFoundTemplate != null)
+{
+    <p>Selected People:</p>
+    foreach (var person in SelectedPeopleWithNotFoundTemplate)
+    {
+        <p>@person.Firstname @person.Lastname</p>
+    }
+    <hr />
+}
 
 <h1>Blazored Typeahead - Header and footer templates</h1>
 
@@ -187,6 +222,7 @@
     private Person SelectedPersonNull;
     private int? SelectedPersonId;
     private IList<Person> SelectedPeople;
+    private IList<Person> SelectedPeopleWithNotFoundTemplate;
     private FormExample FormModel = new FormExample();
     private BlazoredTypeahead<Person, Person> LocalBlazoredTypeahead;
 
@@ -265,5 +301,14 @@
     public Person LoadSelectedPerson(int? id)
     {
         return People.FirstOrDefault(p => p.Id == id);
+    }
+
+    private readonly Random _random = new Random();
+    private Task<Person> ItemAddedMethod(string searchText)
+    {
+        var randomPerson = People[_random.Next(People.Count - 1)];
+        var newPerson = new Person(_random.Next(1000, int.MaxValue), searchText, randomPerson.Lastname, _random.Next(10, 70), randomPerson.Location);
+        People.Add(newPerson);
+        return Task.FromResult(newPerson);
     }
 }

--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor
@@ -185,9 +185,19 @@
 
             @if (NotFoundTemplate != null)
             {
-                <div class="blazored-typeahead__notfound">
-                    @NotFoundTemplate
-                </div>
+                @if (AddItemOnEmptyResultMethod != null)
+                {
+                    <div class="blazored-typeahead__result @GetSelectedSuggestionClass(0)"
+                         @onclick="@SelectNotFoundPlaceholder">
+                        @NotFoundTemplate(SearchText)
+                    </div>
+                }
+                else
+                {
+                    <div class="blazored-typeahead__notfound">
+                        @NotFoundTemplate(SearchText)
+                    </div>    
+                }
             }
             else
             {


### PR DESCRIPTION
## Situation
I would like to have the possibility to add an item using the typeahead component without the need to submit a form with all its data. This would be useful in cases like a label which is nothing more than plain text.

## Description
This PR will add a new parameter to the typeahead component called `AddItemOnEmptyResultMethod`,
the parameter will change the `NotFoundTemplate` to be a selectable item just like the search results, this item will however use the `NotFoundTemplate` as the Template instead of the `ResultTemplate`.


## Warning
This adds a context to the `NotFoundTemplate` and will therefore **not** work out of the box when `updating`, this context is added to let the user create the template with the search input. The searchinput can then be used within the template for extra possibilities.
The context is not necessary and can be removed if requested, but is quite useful to fil the template with a placeholder like `Add "SearchInput" as a new label`
