### PR TITLE
Added a dynamic component builder

### DIFF
--- a/samples/BlazorServer/Pages/Index.razor
+++ b/samples/BlazorServer/Pages/Index.razor
@@ -1,5 +1,9 @@
 ﻿@page "/"
 
+@using Blazored.Typeahead.DynamicComponent;
+@using System.Runtime.Serialization
+@using System.IO
+
 <h1>Blazored Typeahead - Form</h1>
 
 <EditForm Model="FormModel" OnValidSubmit="HandleFormSubmit">
@@ -189,6 +193,26 @@
     <hr />
 }
 
+<h1>Blazored Typeahead - Dynamic-select - Create component using the dynamic component builder</h1>
+
+@if (_blazoredTypeaheadBuilder != null)
+{
+    @_blazoredTypeaheadBuilder.BuildTypeaheadComponent(StateHasChanged)
+}
+
+<button class="btn btn-primary" style="margin-top: 20px;" @onclick="@(AddFooterTemplate)">@(_blazoredTypeaheadBuilder.FooterTemplate == null ? "Add footer template" : "Remove footer template")</button>
+<button class="btn btn-primary" style="margin-top: 20px;" @onclick="@(ChangeComponentType)">@(_blazoredTypeaheadBuilder.IsMultiSelect ? "Switch to single select" : "Switch to multi-select")</button>
+<hr />
+
+<h1>Blazored Typeahead - Dynamic-select - Create component using the typeaheadmodel component</h1>
+
+<BlazoredTypeaheadModel ConfigModel="_configModelForComponent"></BlazoredTypeaheadModel>
+
+<button class="btn btn-primary" style="margin-top: 20px;" @onclick="@(AddFooterTemplateForComponent)">@(_configModelForComponent.FooterTemplate == null ? "Add footer template" : "Remove footer template")</button>
+<button class="btn btn-primary" style="margin-top: 20px;" @onclick="@(ChangeComponentTypeForComponent)">@(_configModelForComponent.IsMultiSelect ? "Switch to single select" : "Switch to multi-select")</button>
+<button class="btn btn-primary" style="margin-top: 20px;" @onclick="@(ChangeModelReference)">Change to copy of dynamic component builder</button>
+<hr />
+
 @code {
 
     private bool IsDisabled = true;
@@ -205,6 +229,8 @@
 
     protected override void OnInitialized()
     {
+        CreateTypeaheadComponent();
+
         People.AddRange(new List<Person>() {
             new Person() { Id = 1, Firstname = "Martelle", Lastname = "Cullon" },
             new Person() { Id = 2, Firstname = "Zelda", Lastname = "Abrahamsson" },
@@ -289,4 +315,113 @@
         return Task.FromResult(newPerson);
     }
 
+    private BlazoredTypeaheadBuilder<Person, Person> _blazoredTypeaheadBuilder;
+
+    private BlazoredTypeaheadConfigModel<Person, Person> _configModel;
+    private BlazoredTypeaheadConfigModel<Person, Person> _configModelForComponent;
+
+    private void CreateTypeaheadComponent()
+    {
+        _configModel = new BlazoredTypeaheadConfigModel<Person, Person>
+        {
+            IsMultiSelect = true,
+            SearchMethod = GetPeopleLocal,
+            SelectedTemplate = _createDynamicComponent,
+            ResultTemplate = _createDynamicComponent,
+            EnableDropDown = true,
+            Debounce = 300,
+            MinimumLength = 2,
+            ShowDropDownOnFocus = true,
+            Placeholder = "dynamic component",
+            AdditionalAttributes = new ObservableDictionary<string, object> { { "id", "dynamic-aliases" } }
+        };
+
+        _blazoredTypeaheadBuilder = new BlazoredTypeaheadBuilder<Person, Person>(_configModel, true);
+
+        _configModelForComponent = new BlazoredTypeaheadConfigModel<Person, Person>
+        {
+            IsMultiSelect = true,
+            SearchMethod = GetPeopleLocal,
+            SelectedTemplate = _createDynamicComponent,
+            ResultTemplate = _createDynamicComponent,
+            EnableDropDown = true,
+            Debounce = 300,
+            MinimumLength = 2,
+            ShowDropDownOnFocus = true,
+            Placeholder = "dynamic component using component",
+            AdditionalAttributes = new ObservableDictionary<string, object> { { "id", "dynamic-aliases" } }
+        };
+    }
+
+    private void AddFooterTemplate()
+    {
+        // Alternatively, setting the _configModel.FooterTemplate would do the same as this code
+        _blazoredTypeaheadBuilder.FooterTemplate = _blazoredTypeaheadBuilder.FooterTemplate == null ? _createDynamicFooter : null;
+    }
+
+    private void AddFooterTemplateForComponent()
+    {
+        // Set the footer template for the component config
+        _configModelForComponent.FooterTemplate = _configModelForComponent.FooterTemplate == null ? _createDynamicFooter : null;
+    }
+
+    private void ChangeComponentType()
+    {
+        _configModel.IsMultiSelect = !_configModel.IsMultiSelect;
+
+        // Alternatively, using the code beneath will manually change the builder to use multiselect
+        // if (_blazoredTypeaheadBuilder.IsMultiSelect)
+        // {
+        //     _blazoredTypeaheadBuilder.ChangeToSingleSelect(() => _configModel.Value, person => _configModel.Value = person);
+        // }
+        // else
+        // {
+        //     _blazoredTypeaheadBuilder.ChangeToMultiSelect(() => _configModel.Values, people => _configModel.Values = people);
+        // }
+    }
+
+    private void ChangeComponentTypeForComponent()
+    {
+        // Set the multi-select for the component config
+        _configModelForComponent.IsMultiSelect = !_configModelForComponent.IsMultiSelect;
+    }
+
+    private void ChangeModelReference()
+    {
+
+        var serializer = new DataContractSerializer(_configModel.GetType());
+
+        using (var ms = new MemoryStream())
+        {
+            serializer.WriteObject(ms, _configModel);
+
+            ms.Seek(0, SeekOrigin.Begin);
+
+            var copyOfModel = (BlazoredTypeaheadConfigModel<Person, Person>)serializer.ReadObject(ms);
+
+            // Serialization does not support Funcs or render fragements so these need to be manually set
+            copyOfModel.SearchMethod = _configModel.SearchMethod;
+            copyOfModel.AddItemOnEmptyResultMethod = _configModel.AddItemOnEmptyResultMethod;
+            copyOfModel.ConvertMethod = _configModel.ConvertMethod;
+
+            copyOfModel.SelectedTemplate = _configModel.SelectedTemplate;
+            copyOfModel.ResultTemplate = _configModel.ResultTemplate;
+            copyOfModel.HelpTemplate = _configModel.HelpTemplate;
+            copyOfModel.NotFoundTemplate = _configModel.NotFoundTemplate;
+            copyOfModel.HeaderTemplate = _configModel.HeaderTemplate;
+            copyOfModel.FooterTemplate = _configModel.FooterTemplate;
+
+            _configModelForComponent = copyOfModel;
+        }
+    }
+
+    readonly RenderFragment<Person> _createDynamicComponent = message => __builder =>
+    {
+        @message.FullName
+    };
+
+    readonly RenderFragment _createDynamicFooter = __builder =>
+    {
+        <button class="btn btn-outline-primary">Constructed using the dynamic component builder</button>
+    };
 }

--- a/samples/BlazorWebAssembly/Pages/Index.razor
+++ b/samples/BlazorWebAssembly/Pages/Index.razor
@@ -1,4 +1,5 @@
 ﻿@page "/"
+@using Blazored.Typeahead.DynamicComponent
 @inject HttpClient httpClient
 
 <h1>Blazored Typeahead - Form</h1>
@@ -209,7 +210,29 @@
 @if (SelectedPersonId != null && SelectedPersonId > 0)
 {
     <p>Selected Person Id: @SelectedPersonId</p>
+    <hr />
 }
+
+
+<h1>Blazored Typeahead - Dynamic-select - Create component using the dynamic component builder</h1>
+
+@if (_blazoredTypeaheadBuilder != null)
+{
+    @_blazoredTypeaheadBuilder.BuildTypeaheadComponent(StateHasChanged)
+}
+
+<button class="btn btn-primary" style="margin-top: 20px;" @onclick="@(AddFooterTemplate)">@(_blazoredTypeaheadBuilder.FooterTemplate == null ? "Add footer template" : "Remove footer template")</button>
+<button class="btn btn-primary" style="margin-top: 20px;" @onclick="@(ChangeComponentType)">@(_blazoredTypeaheadBuilder.IsMultiSelect ? "Switch to single select" : "Switch to multi-select")</button>
+<hr />
+
+<h1>Blazored Typeahead - Dynamic-select - Create component using the typeaheadmodel component</h1>
+
+<BlazoredTypeaheadModel ConfigModel="_configModelForComponent"></BlazoredTypeaheadModel>
+
+<button class="btn btn-primary" style="margin-top: 20px;" @onclick="@(AddFooterTemplateForComponent)">@(_configModelForComponent.FooterTemplate == null ? "Add footer template" : "Remove footer template")</button>
+<button class="btn btn-primary" style="margin-top: 20px;" @onclick="@(ChangeComponentTypeForComponent)">@(_configModelForComponent.IsMultiSelect ? "Switch to single select" : "Switch to multi-select")</button>
+<button class="btn btn-primary" style="margin-top: 20px;" @onclick="@(ChangeModelReference)">Change model reference</button>
+<hr />
 
 @code {
 
@@ -228,6 +251,8 @@
 
     protected override void OnInitialized()
     {
+        CreateTypeaheadComponent();
+
         People.AddRange(new List<Person>() {
             new Person() { Id = 1, Firstname = "Martelle", Lastname = "Cullon" },
             new Person() { Id = 2, Firstname = "Zelda", Lastname = "Abrahamsson" },
@@ -311,4 +336,104 @@
         People.Add(newPerson);
         return Task.FromResult(newPerson);
     }
+
+    private BlazoredTypeaheadBuilder<Person, Person> _blazoredTypeaheadBuilder;
+
+    private BlazoredTypeaheadConfigModel<Person, Person> _configModel;
+    private BlazoredTypeaheadConfigModel<Person, Person> _configModelForComponent;
+
+    private void CreateTypeaheadComponent()
+    {
+        _configModel = new BlazoredTypeaheadConfigModel<Person, Person>
+        {
+            IsMultiSelect = true,
+            SearchMethod = GetPeopleLocal,
+            SelectedTemplate = _createDynamicComponent,
+            ResultTemplate = _createDynamicComponent,
+            EnableDropDown = true,
+            Debounce = 300,
+            MinimumLength = 2,
+            ShowDropDownOnFocus = true,
+            Placeholder = "dynamic component",
+            AdditionalAttributes = new ObservableDictionary<string, object> { { "id", "dynamic-aliases" } }
+        };
+
+        _blazoredTypeaheadBuilder = new BlazoredTypeaheadBuilder<Person, Person>(_configModel, true);
+
+        _configModelForComponent = new BlazoredTypeaheadConfigModel<Person, Person>
+        {
+            IsMultiSelect = true,
+            SearchMethod = GetPeopleLocal,
+            SelectedTemplate = _createDynamicComponent,
+            ResultTemplate = _createDynamicComponent,
+            EnableDropDown = true,
+            Debounce = 300,
+            MinimumLength = 2,
+            ShowDropDownOnFocus = true,
+            Placeholder = "dynamic component using component",
+            AdditionalAttributes = new ObservableDictionary<string, object> { { "id", "dynamic-aliases" } }
+        };
+    }
+
+    private void AddFooterTemplate()
+    {
+        // Alternatively, setting the _configModel.FooterTemplate would do the same as this code
+        _blazoredTypeaheadBuilder.FooterTemplate = _blazoredTypeaheadBuilder.FooterTemplate == null ? _createDynamicFooter : null;
+    }
+
+    private void AddFooterTemplateForComponent()
+    {
+        // Set the footer template for the component config
+        _configModelForComponent.FooterTemplate = _configModelForComponent.FooterTemplate == null ? _createDynamicFooter : null;
+    }
+
+    private void ChangeComponentType()
+    {
+        _configModel.IsMultiSelect = !_configModel.IsMultiSelect;
+
+        // Alternatively, using the code beneath will manually change the builder to use multiselect
+        // if (_blazoredTypeaheadBuilder.IsMultiSelect)
+        // {
+        //     _blazoredTypeaheadBuilder.ChangeToSingleSelect(() => _configModel.Value, person => _configModel.Value = person);
+        // }
+        // else
+        // {
+        //     _blazoredTypeaheadBuilder.ChangeToMultiSelect(() => _configModel.Values, people => _configModel.Values = people);
+        // }
+    }
+
+    private void ChangeComponentTypeForComponent()
+    {
+        // Set the multi-select for the component config
+        _configModelForComponent.IsMultiSelect = !_configModelForComponent.IsMultiSelect;
+    }
+
+    private void ChangeModelReference()
+    {
+        // For some reason wasm crashes when working with a data serializer so we only create a new reference and not a copy of an existing reference
+        _configModelForComponent = new BlazoredTypeaheadConfigModel<Person, Person>
+        {
+            Value = People[_random.Next(People.Count)],
+            IsMultiSelect = false,
+            SearchMethod = GetPeopleLocal,
+            SelectedTemplate = _createDynamicComponent,
+            ResultTemplate = _createDynamicComponent,
+            EnableDropDown = true,
+            Debounce = 300,
+            MinimumLength = 2,
+            ShowDropDownOnFocus = true,
+            Placeholder = "dynamic component using component",
+            AdditionalAttributes = new ObservableDictionary<string, object> { { "id", "dynamic-aliases" } }
+        };
+    }
+
+    readonly RenderFragment<Person> _createDynamicComponent = message => __builder =>
+    {
+        @message.FullName
+    };
+
+    readonly RenderFragment _createDynamicFooter = __builder =>
+    {
+        <button class="btn btn-outline-primary">Constructed using the dynamic component builder</button>
+    };
 }

--- a/samples/Shared/Person.cs
+++ b/samples/Shared/Person.cs
@@ -20,5 +20,21 @@ namespace Sample.Shared
         public string FullName { get => Firstname + " " + Lastname; }
         public int Age { get; set; }
         public string Location { get; set; }
+
+        // Override the equals as the reference to the person object is different when deserializing the BlazoredTypeaheadConfigModel
+        public override bool Equals(object obj)
+        {
+            if (obj is Person person)
+            {
+                return person.Id == Id;
+            }
+
+            return base.Equals(obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
     }
 }

--- a/src/Blazored.Typeahead/BlazoredTypeaheadModel.razor
+++ b/src/Blazored.Typeahead/BlazoredTypeaheadModel.razor
@@ -1,0 +1,7 @@
+﻿@typeparam TItem
+@typeparam TValue
+
+@if (_builder != null)
+{
+    @_builder.BuildTypeaheadComponent(StateHasChanged)
+}

--- a/src/Blazored.Typeahead/BlazoredTypeaheadModel.razor.cs
+++ b/src/Blazored.Typeahead/BlazoredTypeaheadModel.razor.cs
@@ -1,0 +1,28 @@
+﻿using Blazored.Typeahead.DynamicComponent;
+using Microsoft.AspNetCore.Components;
+
+namespace Blazored.Typeahead
+{
+    public partial class BlazoredTypeaheadModel<TItem, TValue>
+    {
+        [Parameter]
+        public BlazoredTypeaheadConfigModel<TItem, TValue> ConfigModel { get; set; }
+
+        private BlazoredTypeaheadConfigModel<TItem, TValue> _configModel;
+        private BlazoredTypeaheadBuilder<TItem, TValue> _builder;
+
+        protected override void OnParametersSet()
+        {
+            base.OnParametersSet();
+
+            // The builder will rerender on change, so only recreate the builder when the reference to the object is different
+            if (_builder != null && ConfigModel.Equals(_configModel))
+            {
+                return;
+            }
+
+            _builder = new BlazoredTypeaheadBuilder<TItem, TValue>(ConfigModel, true);
+            _configModel = ConfigModel;
+        }
+    }
+}

--- a/src/Blazored.Typeahead/DynamicComponent/BlazoredTypeaheadBuilder.cs
+++ b/src/Blazored.Typeahead/DynamicComponent/BlazoredTypeaheadBuilder.cs
@@ -1,0 +1,378 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using static Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers;
+
+namespace Blazored.Typeahead.DynamicComponent
+{
+    public class BlazoredTypeaheadBuilder<TItem, TValue>
+    {
+        protected IDictionary<string, object> attributes = new Dictionary<string, object>(20);
+        protected IDictionary<string, object> additionalAttributes = new Dictionary<string, object>();
+        protected Action stateHasChanged;
+
+        protected Func<IList<TValue>> GetValues { get; set; }
+        protected Action<IList<TValue>> SetValues { get; set; }
+
+        protected Func<TValue> GetValue { get; set; }
+        protected Action<TValue> SetValue { get; set; }
+
+        public TValue Value
+        {
+            get => GetValue();
+            set
+            {
+                SetValue(value);
+                stateHasChanged();
+            }
+        }
+
+        public IList<TValue> Values
+        {
+            get => GetValues();
+            set
+            {
+                SetValues(value);
+                stateHasChanged();
+            }
+        }
+
+        public bool IsMultiSelect { get; protected set; }
+
+        public void ChangeToSingleSelect(Func<TValue> getValue, Action<TValue> setValue)
+        {
+            GetValue = getValue;
+            SetValue = setValue;
+            IsMultiSelect = false;
+            stateHasChanged?.Invoke();
+        }
+
+        public void ChangeToMultiSelect(Func<IList<TValue>> getValues, Action<IList<TValue>> setValues)
+        {
+            GetValues = getValues;
+            SetValues = setValues;
+            IsMultiSelect = true;
+            stateHasChanged?.Invoke();
+        }
+
+        public Func<string, Task<IEnumerable<TItem>>> SearchMethod
+        {
+            get => GetAttribute<Func<string, Task<IEnumerable<TItem>>>>(nameof(BlazoredTypeahead<object, object>.SearchMethod));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.SearchMethod), value);
+        }
+
+        public Func<TItem, TValue> ConvertMethod
+        {
+            get => GetAttribute<Func<TItem, TValue>>(nameof(BlazoredTypeahead<object, object>.ConvertMethod));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.ConvertMethod), value);
+        }
+
+        public Func<string, Task<TItem>> AddItemOnEmptyResultMethod
+        {
+            get => GetAttribute<Func<string, Task<TItem>>>(nameof(BlazoredTypeahead<object, object>.AddItemOnEmptyResultMethod));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.AddItemOnEmptyResultMethod), value);
+        }
+
+        public RenderFragment<TValue> SelectedTemplate
+        {
+            get => GetAttribute<RenderFragment<TValue>>(nameof(BlazoredTypeahead<object, object>.SelectedTemplate));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.SelectedTemplate), value);
+        }
+
+        public RenderFragment<TItem> ResultTemplate
+        {
+            get => GetAttribute<RenderFragment<TItem>>(nameof(BlazoredTypeahead<object, object>.ResultTemplate));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.ResultTemplate), value);
+        }
+
+        public RenderFragment HelpTemplate
+        {
+            get => GetAttribute<RenderFragment>(nameof(BlazoredTypeahead<object, object>.HelpTemplate));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.HelpTemplate), value);
+        }
+
+        public RenderFragment<string> NotFoundTemplate
+        {
+            get => GetAttribute<RenderFragment<string>>(nameof(BlazoredTypeahead<object, object>.NotFoundTemplate));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.NotFoundTemplate), value);
+        }
+
+        public RenderFragment HeaderTemplate
+        {
+            get => GetAttribute<RenderFragment>(nameof(BlazoredTypeahead<object, object>.HeaderTemplate));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.HeaderTemplate), value);
+        }
+
+        public RenderFragment FooterTemplate
+        {
+            get => GetAttribute<RenderFragment>(nameof(BlazoredTypeahead<object, object>.FooterTemplate));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.FooterTemplate), value);
+        }
+
+        public int? MinimumLength
+        {
+            get => GetAttribute<int?>(nameof(BlazoredTypeahead<object, object>.MinimumLength));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.MinimumLength), value);
+        }
+
+        public int? Debounce
+        {
+            get => GetAttribute<int?>(nameof(BlazoredTypeahead<object, object>.Debounce));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.Debounce), value);
+        }
+
+        public int? MaximumSuggestions
+        {
+            get => GetAttribute<int?>(nameof(BlazoredTypeahead<object, object>.MaximumSuggestions));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.MaximumSuggestions), value);
+        }
+
+        public bool? Disabled
+        {
+            get => GetAttribute<bool?>(nameof(BlazoredTypeahead<object, object>.Disabled));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.Disabled), value);
+        }
+
+        public bool? EnableDropDown
+        {
+            get => GetAttribute<bool?>(nameof(BlazoredTypeahead<object, object>.EnableDropDown));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.EnableDropDown), value);
+        }
+
+        public bool? ShowDropDownOnFocus
+        {
+            get => GetAttribute<bool?>(nameof(BlazoredTypeahead<object, object>.ShowDropDownOnFocus));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.ShowDropDownOnFocus), value);
+        }
+
+        public bool? DisableClear
+        {
+            get => GetAttribute<bool?>(nameof(BlazoredTypeahead<object, object>.DisableClear));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.DisableClear), value);
+        }
+
+        public string Placeholder
+        {
+            get => GetAttribute<string>("placeholder");
+            set => SetAttribute("placeholder", value);
+        }
+
+        public bool? StopPropagation
+        {
+            get => GetAttribute<bool?>(nameof(BlazoredTypeahead<object, object>.StopPropagation));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.StopPropagation), value);
+        }
+
+        public bool? PreventDefault
+        {
+            get => GetAttribute<bool?>(nameof(BlazoredTypeahead<object, object>.PreventDefault));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.PreventDefault), value);
+        }
+
+        private BlazoredTypeaheadBuilder()
+        {
+            // The renderfragments need to always be added as attributes, otherwise changes in these properties will not be shown
+            SelectedTemplate = null;
+            ResultTemplate = null;
+            HelpTemplate = null;
+            NotFoundTemplate = null;
+            HeaderTemplate = null;
+            FooterTemplate = null;
+        }
+
+        public BlazoredTypeaheadBuilder(Func<TValue> getValue, Action<TValue> setValue)
+            : this()
+        {
+            GetValue = getValue;
+            SetValue = setValue;
+            IsMultiSelect = false;
+        }
+
+        public BlazoredTypeaheadBuilder(Func<IList<TValue>> getValues, Action<IList<TValue>> setValues)
+            : this()
+        {
+            GetValues = getValues;
+            SetValues = setValues;
+            IsMultiSelect = true;
+        }
+
+        public BlazoredTypeaheadBuilder(BlazoredTypeaheadConfigModel<TItem, TValue> configModel, bool renderOnModelChange = false)
+        {
+            if (configModel == null)
+            {
+                throw new ArgumentNullException(nameof(configModel));
+            }
+
+            if (renderOnModelChange)
+            {
+                configModel.PropertyChanged += ConfigModelOnPropertyChanged;
+                configModel.CollectionChanged += ConfigModelOnCollectionChanged;
+            }
+
+            IsMultiSelect = configModel.IsMultiSelect;
+
+            if (configModel.IsMultiSelect)
+            {
+                GetValues = () => configModel.Values;
+                SetValues = values => configModel.Values = values;
+            }
+            else
+            {
+                GetValue = () => configModel.Value;
+                SetValue = value => configModel.Value = value;
+            }
+
+            attributes = (IDictionary<string, object>) configModel.Attibutes;
+            additionalAttributes = configModel.AdditionalAttributes;
+        }
+
+        private void ConfigModelOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            var configModel = (BlazoredTypeaheadConfigModel<TItem, TValue>) sender;
+            additionalAttributes = configModel.AdditionalAttributes;
+            stateHasChanged?.Invoke();
+        }
+
+        private void ConfigModelOnPropertyChanged(object sender, PropertyChangedEventArgs args)
+        {
+            var configModel = (BlazoredTypeaheadConfigModel<TItem, TValue>) sender;
+
+            switch (args.PropertyName)
+            {
+                // Multiselect is a special case as it has custom logic attached to it
+                case nameof(configModel.IsMultiSelect):
+                    IsMultiSelect = configModel.IsMultiSelect;
+
+                    if (configModel.IsMultiSelect)
+                    {
+                        GetValues = () => configModel.Values;
+                        SetValues = values => configModel.Values = values;
+                    }
+                    else
+                    {
+                        GetValue = () => configModel.Value;
+                        SetValue = value => configModel.Value = value;
+                    }
+
+                    stateHasChanged?.Invoke();
+                    break;
+                default:
+                    attributes = (IDictionary<string, object>) configModel.Attibutes;
+                    stateHasChanged?.Invoke();
+                    break;
+            }
+        }
+
+        protected virtual T GetAttribute<T>(string property)
+        {
+            if (attributes.TryGetValue(property, out var value))
+            {
+                return (T) value;
+            }
+
+            return default;
+        }
+
+        protected virtual void SetAttribute(string property, object value)
+        {
+            attributes[property] = value;
+            stateHasChanged?.Invoke();
+        }
+
+        protected virtual void SetAttributes(IDictionary<string, object> newAttributes)
+        {
+            foreach (var (property, value) in newAttributes)
+            {
+                attributes[property] = value;
+            }
+
+            stateHasChanged?.Invoke();
+        }
+
+        public virtual T GetAdditionalAttribute<T>(string property)
+        {
+            if (additionalAttributes.TryGetValue(property, out var value))
+            {
+                return (T)value;
+            }
+
+            return default;
+        }
+
+        public virtual void SetAdditionalAttribute(string property, object value)
+        {
+            additionalAttributes[property] = value;
+            stateHasChanged?.Invoke();
+        }
+
+        public virtual void SetAdditionalAttributes(IDictionary<string, object> newAttributes)
+        {
+            foreach (var (property, value) in newAttributes)
+            {
+                additionalAttributes[property] = value;
+            }
+
+            stateHasChanged?.Invoke();
+        }
+
+        public virtual RenderFragment BuildTypeaheadComponent(Action stateHasChangedMethod) => __builder =>
+        {
+            if (stateHasChangedMethod == null)
+            {
+                throw new ArgumentNullException(nameof(stateHasChangedMethod));
+            }
+
+            var index = 0;
+            stateHasChanged = stateHasChangedMethod;
+
+            __builder.OpenComponent<BlazoredTypeahead<TItem, TValue>>(index++);
+
+            BuildComponent(ref __builder, ref index);
+
+            __builder.CloseComponent();
+        };
+
+        protected virtual void BuildComponent(ref RenderTreeBuilder __builder, ref int index)
+        {
+            Expression<Func<IList<TValue>>> valuesExpression = () => Values;
+            Expression<Func<TValue>> valueExpression = () => Value;
+
+            if (IsMultiSelect)
+            {
+                Debug.Assert(GetValues != null && SetValues != null);
+                __builder.AddAttribute(index++, nameof(BlazoredTypeahead<object, object>.Values), TypeCheck(Values));
+                __builder.AddAttribute(index++, "ValuesChanged", TypeCheck(EventCallback.Factory.Create(this, CreateInferredEventCallback(this, __value => Values = __value, Values))));
+                __builder.AddAttribute(index++, "ValuesExpression", valuesExpression);
+
+                // The typeahead component interally uses these fields to decide if the component is multi select or not, so we reset these fields
+                __builder.AddAttribute(index++, nameof(BlazoredTypeahead<object, object>.Value), (object)null);
+                __builder.AddAttribute(index++, "ValueChanged", default(EventCallback<TValue>));
+                __builder.AddAttribute(index++, "ValueExpression", (object)null);
+            }
+            else
+            {
+                Debug.Assert(GetValue != null && SetValue != null);
+                __builder.AddAttribute(index++, nameof(BlazoredTypeahead<object, object>.Value), TypeCheck(Value));
+                __builder.AddAttribute(index++, "ValueChanged", TypeCheck(EventCallback.Factory.Create(this, CreateInferredEventCallback(this, __value => Value = __value, Value))));
+                __builder.AddAttribute(index++, "ValueExpression", valueExpression);
+
+                // The typeahead component interally uses these fields to decide if the component is multi select or not, so we reset these fields
+                __builder.AddAttribute(index++, nameof(BlazoredTypeahead<object, object>.Values), (object)null);
+                __builder.AddAttribute(index++, "ValuesChanged", default(EventCallback<IList<TValue>>));
+                __builder.AddAttribute(index++, "ValuesExpression", (object)null);
+            }
+
+            __builder.AddMultipleAttributes(index++, attributes);
+
+            __builder.AddMultipleAttributes(index++,
+                additionalAttributes.Where(item => !attributes.ContainsKey(item.Key)));
+        }
+    }
+}

--- a/src/Blazored.Typeahead/DynamicComponent/BlazoredTypeaheadConfigModel.cs
+++ b/src/Blazored.Typeahead/DynamicComponent/BlazoredTypeaheadConfigModel.cs
@@ -1,0 +1,331 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+namespace Blazored.Typeahead.DynamicComponent
+{
+    [DataContract]
+    public class BlazoredTypeaheadConfigModel<TItem, TValue> : INotifyPropertyChanged, INotifyCollectionChanged
+    {
+        private bool _isMultiSelect;
+        private TValue _value;
+        private IList<TValue> _values;
+
+        private ObservableDictionary<string, object> _additionalAttributes;
+        private IDictionary<string, object> _attributes;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        public event NotifyCollectionChangedEventHandler? CollectionChanged;
+
+        public Func<string, Task<IEnumerable<TItem>>> SearchMethod
+        {
+            get => GetAttribute<Func<string, Task<IEnumerable<TItem>>>>(nameof(BlazoredTypeahead<object, object>.SearchMethod));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.SearchMethod), value);
+        }
+
+        public Func<TItem, TValue> ConvertMethod
+        {
+            get => GetAttribute<Func<TItem, TValue>>(nameof(BlazoredTypeahead<object, object>.ConvertMethod));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.ConvertMethod), value);
+        }
+
+        public Func<string, Task<TItem>> AddItemOnEmptyResultMethod
+        {
+            get => GetAttribute<Func<string, Task<TItem>>>(nameof(BlazoredTypeahead<object, object>.AddItemOnEmptyResultMethod));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.AddItemOnEmptyResultMethod), value);
+        }
+
+        public RenderFragment<TValue> SelectedTemplate
+        {
+            get => GetAttribute<RenderFragment<TValue>>(nameof(BlazoredTypeahead<object, object>.SelectedTemplate));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.SelectedTemplate), value);
+        }
+
+        public RenderFragment<TItem> ResultTemplate
+        {
+            get => GetAttribute<RenderFragment<TItem>>(nameof(BlazoredTypeahead<object, object>.ResultTemplate));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.ResultTemplate), value);
+        }
+
+        public RenderFragment HelpTemplate
+        {
+            get => GetAttribute<RenderFragment>(nameof(BlazoredTypeahead<object, object>.HelpTemplate));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.HelpTemplate), value);
+        }
+
+        public RenderFragment<string> NotFoundTemplate
+        {
+            get => GetAttribute<RenderFragment<string>>(nameof(BlazoredTypeahead<object, object>.NotFoundTemplate));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.NotFoundTemplate), value);
+        }
+
+        public RenderFragment HeaderTemplate
+        {
+            get => GetAttribute<RenderFragment>(nameof(BlazoredTypeahead<object, object>.HeaderTemplate));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.HeaderTemplate), value);
+        }
+
+        public RenderFragment FooterTemplate
+        {
+            get => GetAttribute<RenderFragment>(nameof(BlazoredTypeahead<object, object>.FooterTemplate));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.FooterTemplate), value);
+        }
+
+        public int? MinimumLength
+        {
+            get => GetAttribute<int?>(nameof(BlazoredTypeahead<object, object>.MinimumLength));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.MinimumLength), value);
+        }
+
+        public int? Debounce
+        {
+            get => GetAttribute<int?>(nameof(BlazoredTypeahead<object, object>.Debounce));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.Debounce), value);
+        }
+
+        public int? MaximumSuggestions
+        {
+            get => GetAttribute<int?>(nameof(BlazoredTypeahead<object, object>.MaximumSuggestions));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.MaximumSuggestions), value);
+        }
+
+        public bool? Disabled
+        {
+            get => GetAttribute<bool?>(nameof(BlazoredTypeahead<object, object>.Disabled));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.Disabled), value);
+        }
+
+        public bool? EnableDropDown
+        {
+            get => GetAttribute<bool?>(nameof(BlazoredTypeahead<object, object>.EnableDropDown));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.EnableDropDown), value);
+        }
+
+        public bool? ShowDropDownOnFocus
+        {
+            get => GetAttribute<bool?>(nameof(BlazoredTypeahead<object, object>.ShowDropDownOnFocus));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.ShowDropDownOnFocus), value);
+        }
+
+        public bool? DisableClear
+        {
+            get => GetAttribute<bool?>(nameof(BlazoredTypeahead<object, object>.DisableClear));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.DisableClear), value);
+        }
+
+        public string Placeholder
+        {
+            get => GetAttribute<string>("placeholder");
+            set => SetAttribute("placeholder", value);
+        }
+
+        public bool? StopPropagation
+        {
+            get => GetAttribute<bool?>(nameof(BlazoredTypeahead<object, object>.StopPropagation));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.StopPropagation), value);
+        }
+
+        public bool? PreventDefault
+        {
+            get => GetAttribute<bool?>(nameof(BlazoredTypeahead<object, object>.PreventDefault));
+            set => SetAttribute(nameof(BlazoredTypeahead<object, object>.PreventDefault), value);
+        }
+
+        [DataMember]
+        public bool IsMultiSelect
+        {
+            get => _isMultiSelect;
+            set
+            {
+                _isMultiSelect = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public TValue Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public IList<TValue> Values
+        {
+            get => _values ?? new List<TValue>();
+            set
+            {
+                _values = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public ObservableDictionary<string, object> AdditionalAttributes
+        {
+            get => _additionalAttributes;
+            set
+            {
+                if (_additionalAttributes != null)
+                {
+                    _additionalAttributes.CollectionChanged -= AdditionalAttributesOnCollectionChanged;
+                }
+
+                _additionalAttributes = value;
+
+                if (_additionalAttributes != null)
+                {
+                    _additionalAttributes.CollectionChanged += AdditionalAttributesOnCollectionChanged;
+                }
+
+                OnPropertyChanged();
+            }
+        }
+
+        public IReadOnlyDictionary<string, object> Attibutes => (IReadOnlyDictionary<string, object>) _attributes;
+
+        public BlazoredTypeaheadConfigModel()
+        {
+            _attributes = new Dictionary<string, object>(20);
+            _additionalAttributes = new ObservableDictionary<string, object>();
+            _additionalAttributes.CollectionChanged += AdditionalAttributesOnCollectionChanged;
+
+            // The renderfragments need to always be added as attributes, otherwise changes in these properties will not be shown
+            ResetRenderTemplates();
+        }
+
+        private void ResetRenderTemplates()
+        {
+            SelectedTemplate = null;
+            ResultTemplate = null;
+            HelpTemplate = null;
+            NotFoundTemplate = null;
+            HeaderTemplate = null;
+            FooterTemplate = null;
+        }
+
+        private void AdditionalAttributesOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            CollectionChanged?.Invoke(this, e);
+        }
+
+        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        protected virtual T GetAttribute<T>(string property)
+        {
+            if (_attributes.TryGetValue(property, out var value))
+            {
+                return (T)value;
+            }
+
+            return default;
+        }
+
+        protected virtual void SetAttribute(string property, object value)
+        {
+            _attributes[property] = value;
+            OnPropertyChanged(property);
+        }
+
+        public virtual T GetAdditionalAttribute<T>(string property)
+        {
+            if (_additionalAttributes.TryGetValue(property, out var value))
+            {
+                return (T)value;
+            }
+
+            return default;
+        }
+
+        public virtual void SetAdditionalAttribute(string property, object value)
+        {
+            _additionalAttributes[property] = value;
+            OnPropertyChanged(nameof(AdditionalAttributes));
+        }
+
+        public virtual void SetAdditionalAttributes(IDictionary<string, object> newAttributes)
+        {
+            foreach (var (property, value) in newAttributes)
+            {
+                _additionalAttributes[property] = value;
+            }
+
+            OnPropertyChanged(nameof(AdditionalAttributes));
+        }
+        
+        #region Serialization
+
+        [OnDeserializing]
+        private void OnDeserializing(StreamingContext context)
+        {
+            // Call the constructor as this will init the collections
+            this.GetType().GetConstructor(Array.Empty<Type>()).Invoke(this, null);
+        }
+
+        [OnDeserialized]
+        private void OnDeserialized(StreamingContext context)
+        {
+            // Because Values is of type IList, it will be deserialized into an array
+            // The code however does not support working with an array and will throw an exception when adding or removing items
+            Values = Values.ToList();
+        }
+
+        /// <summary>
+        /// This should ONLY be set by the deserializer and not manually
+        /// </summary>
+        [DataMember] private Dictionary<string, object> SerializableAttributes
+        {
+            get => GetSerializableAttributes();
+            set => _attributes = value;
+        }
+
+        /// <summary>
+        /// This should ONLY be set by the deserializer and not manually
+        /// </summary>
+        [DataMember] private Dictionary<string, object> SerializableAdditionalAttributes
+        {
+            get => GetSerializableAdditionalAttributes();
+            set => _additionalAttributes = new ObservableDictionary<string, object>(value);
+        }
+
+        protected virtual Dictionary<string, object> GetSerializableAdditionalAttributes()
+        {
+            return GetSerialiableProperties(_additionalAttributes)
+                .ToDictionary(pair => pair.Key, pair => pair.Value);
+        }
+
+        protected virtual Dictionary<string, object> GetSerializableAttributes()
+        {
+            return GetSerialiableProperties(_attributes)
+                .ToDictionary(pair => pair.Key, pair => pair.Value);
+        }
+
+        protected virtual IEnumerable<KeyValuePair<string, object>> GetSerialiableProperties(IDictionary<string, object> serializableDictionary)
+        {
+            return serializableDictionary
+                .Where(item =>
+                {
+                    if (item.Value == null)
+                    {
+                        return false;
+                    }
+
+                    return item.Value.GetType().IsPrimitive || item.Value is string;
+                });
+        }
+
+        #endregion
+    }
+}

--- a/src/Blazored.Typeahead/DynamicComponent/ObservableDictionary.cs
+++ b/src/Blazored.Typeahead/DynamicComponent/ObservableDictionary.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Blazored.Typeahead.DynamicComponent
+{
+    public class ObservableDictionary<TKey, TValue> : Dictionary<TKey, TValue>, INotifyCollectionChanged
+    {
+        #region Constructors
+
+        public ObservableDictionary() { }
+        public ObservableDictionary(IDictionary<TKey, TValue> dictionary) : base(dictionary) { }
+        public ObservableDictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey> comparer) : base(dictionary, comparer) { }
+        public ObservableDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection) : base(collection) { }
+        public ObservableDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey> comparer) : base(collection, comparer) { }
+        public ObservableDictionary(IEqualityComparer<TKey> comparer) : base(comparer) { }
+        public ObservableDictionary(int capacity) : base(capacity) { }
+        public ObservableDictionary(int capacity, IEqualityComparer<TKey> comparer) : base (capacity, comparer) { }
+
+        #endregion
+
+        public new void Add(TKey key, TValue value)
+        {
+            base.Add(key, value);
+            OnPropertyChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, new KeyValuePair<TKey,TValue>(key, value)));
+        }
+
+        public new TValue this[TKey key]
+        {
+            get => base[key];
+            set
+            {
+                base[key] = value;
+                OnPropertyChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, value));
+            }
+        }
+
+        public new bool TryAdd(TKey key, TValue value)
+        {
+            var result = base.TryAdd(key, value);
+            if (result)
+            {
+                OnPropertyChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, new KeyValuePair<TKey, TValue>(key, value)));
+            }
+
+            return result;
+        }
+
+        public new void Clear()
+        {
+            base.Clear();
+            OnPropertyChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset, this));
+        }
+
+        public new bool Remove(TKey key)
+        {
+            var result = base.Remove(key);
+
+            if (result)
+            {
+                OnPropertyChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, key));
+            }
+
+            return result;
+        }
+
+        public new bool Remove(TKey key, [MaybeNullWhen(false)] out TValue value)
+        {
+            var result = base.Remove(key, out value);
+
+            if (result)
+            {
+                OnPropertyChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, value));
+            }
+
+            return result;
+        }
+
+        protected virtual void OnPropertyChanged(NotifyCollectionChangedEventArgs collectionEventArgs)
+        {
+            CollectionChanged?.Invoke(this, collectionEventArgs);
+        }
+
+        public event NotifyCollectionChangedEventHandler? CollectionChanged;
+    }
+}


### PR DESCRIPTION
## Situation
I would like to have the possibility to completely modify the typeahead component from code and while runtime. While the properties like Debounce are changable at runtime, the more advanced properties like the footertemplate are not configurable at runtime.

## Description
This PR will introduce a builder, model and component which are all but the component designed to be extendable.
The builder allows the user to completely rewrite the component at any given time, be it user input or a timed event.
The model supports serialization and deserialization which allow the user to store the model in a database or in memory model for a later date. The data serialization does however not support serializing Delegates / RenderFragments which will therefore still be reassigned (any suggestions on a way around this would be appriciated).

## Implementation
Current implementation has a extendable generic property implementation, the implementation can be changed to a more extendable per property implementation if it is requested.
Any architectural changes to the implementation can be discussed with me over voice if hard to explain using words.

## Note
1. As I do not have much experience with working with Blazors `RenderTreeBuilder` any performance or implementation improvements are appreciated. 
2. The `WebAssembly` sample does not seem to work with the `DataContractSerializer` and will therefore have a small difference in implementation than the `WebServer` sample implementation, this is also documented in the code.