### PR TITLE
Value Update when bound Property Value is changed from outside

### DIFF
--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
@@ -132,6 +132,15 @@ namespace Blazored.Typeahead
             }
         }
 
+        protected override async Task OnParametersSetAsync()
+        {
+            await base.OnParametersSetAsync();
+
+            await Task.Delay(250);
+
+            Initialize();
+        }
+
         private void Initialize()
         {
             SearchText = "";


### PR DESCRIPTION
Commit 4c6d3ba70e507b1af3ae4ccf683f74e686348d53 removed a line which would update the component's state when the value of the bound item would be changed in the code described by other users here. https://github.com/Blazored/Typeahead/issues/217

By adding a Task.Delay it also allows the selection to be working on any device. This bug is described here. https://github.com/Blazored/Typeahead/issues/128

I'm not sure how to better get rid of the problem, and I currently haven't got the time to investigate further.
I hope this helps in some ways, even if it's just for someone else to give a hint in the right direction of a fix.