### PR TITLE
Added support for an error handler template upon searching

### DIFF
--- a/samples/BlazorServer/Pages/Index.razor
+++ b/samples/BlazorServer/Pages/Index.razor
@@ -189,6 +189,23 @@
     <hr />
 }
 
+<h1>Blazored Typeahead - Error Handler</h1>
+
+<BlazoredTypeahead SearchMethod="@GetErrorPeople"
+                   @bind-Value="@SelectedPersonNull"
+                   placeholder="Search by first name...">
+    <SelectedTemplate Context="person">
+        @person.Firstname
+    </SelectedTemplate>
+    <ResultTemplate Context="person">
+        @person.Firstname @person.Lastname
+    </ResultTemplate>
+    <ErrorTemplate>
+        <span style="color: red;">@context.Message</span>
+    </ErrorTemplate>
+</BlazoredTypeahead>
+<hr />
+
 @code {
 
     private bool IsDisabled = true;
@@ -263,6 +280,16 @@
     private async Task<IEnumerable<Person>> GetPeopleLocal(string searchText)
     {
         return await Task.FromResult(People.Where(x => x.Firstname.ToLower().Contains(searchText.ToLower())).ToList());
+    }
+    
+    private async Task<IEnumerable<Person>> GetErrorPeople(string searchText)
+    {
+        if (searchText.Contains("win", StringComparison.InvariantCultureIgnoreCase))
+        {
+           return await GetPeopleLocal(searchText);
+        }
+
+        throw new InvalidOperationException("Only people with 'win' in name allowed");
     }
 
     private void HandleFormSubmit()

--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor
@@ -214,4 +214,10 @@
             }
         </div>
     }
+    else if (ShowError())
+    {
+        <div class="blazored-typeahead__notfound">  
+            @ErrorTemplate(Error)
+        </div>
+    }
 </div>


### PR DESCRIPTION
The reason for adding this feature is that we use the Typeahead against Azure Search and today they had a brief outage. When the Debounce Timer EllapsedEventHandler have an unhandeled exception the app pool will crash. 

You could catch that exception in the SearchMethod, but this small feature will catch the exception and you can have at it what as you will. If you don't provide a template the behaviour should be as before this feature was implemented. 