### PR TITLE
Fixes #217 - bug where the selected value is not displayed

### DIFF
--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
@@ -132,6 +132,11 @@ namespace Blazored.Typeahead
             }
         }
 
+        protected override void OnParametersSet()
+        {
+            Initialize();
+        }
+
         private void Initialize()
         {
             SearchText = "";
@@ -240,7 +245,7 @@ namespace Blazored.Typeahead
             {
                 await ResetControl();
             }
-            
+
         }
 
         private async Task HandleKeyup(KeyboardEventArgs args)
@@ -403,7 +408,7 @@ namespace Blazored.Typeahead
         private async Task SelectResult(TItem item)
         {
             var value = ConvertMethod(item);
-       
+
             if (IsMultiselect)
             {
                 var valueList = Values ?? new List<TValue>();


### PR DESCRIPTION
Fixed bug where the selected value is not displayed
I think the call to `Initialize` from `OnParametersSet` was removed by mistake in this comment 4c6d3ba70e507b1af3ae4ccf683f74e686348d53 
and then later the commented line was removed.