### PR TITLE
Removed duplicate .invalid section

### DIFF
--- a/src/Blazored.Typeahead/wwwroot/blazored-typeahead.css
+++ b/src/Blazored.Typeahead/wwwroot/blazored-typeahead.css
@@ -46,11 +46,6 @@
     display: none;
 }
 
-.invalid {
-    border-color: red !important;
-}
-
-
 .blazored-typeahead__input-mask-wrapper {
     display: flex;    
     width: 100%;


### PR DESCRIPTION
The .invalid section will already be set through .blazored-typeahead.invalid and fights with other stylesheets out there such as bootstrap.