### PR TITLE
Bugfix/searchtext disappears

### DIFF
--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
@@ -22,7 +22,19 @@ namespace Blazored.Typeahead
 
         [CascadingParameter] private EditContext CascadedEditContext { get; set; }
 
-        [Parameter] public TValue Value { get; set; }
+        private TValue _value;
+        [Parameter] public TValue Value 
+        {
+            get => _value; 
+            set
+            {
+                if (_valueComparer.Equals(_value, value) == false)
+                {
+                    _value = value;
+                    Initialize();
+                }
+            }
+        }
         [Parameter] public EventCallback<TValue> ValueChanged { get; set; }
         [Parameter] public Expression<Func<TValue>> ValueExpression { get; set; }
 
@@ -131,7 +143,6 @@ namespace Blazored.Typeahead
 
         protected override void OnParametersSet()
         {
-            Initialize();
         }
 
         private void Initialize()

--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
@@ -16,6 +16,7 @@ namespace Blazored.Typeahead
         private bool _eventsHookedUp = false;
         private ElementReference _searchInput;
         private ElementReference _mask;
+        private IEqualityComparer<TValue> _valueComparer = EqualityComparer<TValue>.Default;
 
         [Inject] private IJSRuntime JSRuntime { get; set; }
 
@@ -143,7 +144,7 @@ namespace Blazored.Typeahead
         private async Task RemoveValue(TValue item)
         {
             var valueList = Values ?? new List<TValue>();
-            if (valueList.Contains(item))
+            if (valueList.Contains(item, _valueComparer))
             {
                 valueList.Remove(item);
             }
@@ -409,7 +410,7 @@ namespace Blazored.Typeahead
             {
                 var valueList = Values ?? new List<TValue>();
 
-                if (valueList.Contains(value))
+                if (valueList.Contains(value, _valueComparer))
                     valueList.Remove(value);
                 else
                     valueList.Add(value);
@@ -418,7 +419,7 @@ namespace Blazored.Typeahead
             }
             else
             {
-                if (Value != null && Value.Equals(value)) return;
+                if (_valueComparer.Equals(Value, value)) return;
                 Value = value;
                 await ValueChanged.InvokeAsync(value);
             }


### PR DESCRIPTION
Fixes #288 

**Changes**
1. Added an ```IEqualityComparer<TValue>``` for comparing Value and Items in Values-Collection. This should handle all standard cases - including null - and opens up the use of ```IEquatable<T>``` if the user wants more control over equality checking.
2. Checking Value for equality when setting Parameter to prevent re-initialization if the value was not actually changed.