### PR TITLE
Allow custom CSS styles on Typeahead component

### DIFF
--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor
@@ -3,7 +3,7 @@
 @typeparam TItem
 @typeparam TValue
 
-<div class="blazored-typeahead @FieldCssClasses">
+<div class="blazored-typeahead @FieldCssClasses @_classAttribute" style="@_styleAttribute">
 
     <div class="blazored-typeahead__controls">
 

--- a/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
+++ b/src/Blazored.Typeahead/BlazoredTypeahead.razor.cs
@@ -16,6 +16,9 @@ namespace Blazored.Typeahead
         private bool _eventsHookedUp = false;
         private ElementReference _searchInput;
         private ElementReference _mask;
+        private IReadOnlyDictionary<string, object> _capturedAttributes = default!;
+        private string _classAttribute = string.Empty;
+        private string _styleAttribute = string.Empty;
 
         [Inject] private IJSRuntime JSRuntime { get; set; }
 
@@ -108,6 +111,8 @@ namespace Blazored.Typeahead
                 throw new InvalidOperationException($"{GetType()} requires a {nameof(ResultTemplate)} parameter.");
             }
 
+            _capturedAttributes = CaptureCSSAttributes(AdditionalAttributes);
+
             _debounceTimer = new System.Timers.Timer();
             _debounceTimer.Interval = Debounce;
             _debounceTimer.AutoReset = false;
@@ -130,7 +135,8 @@ namespace Blazored.Typeahead
 
         protected override void OnParametersSet()
         {
-            Initialize();
+            //Initialize();
+            IsShowingMask = Value != null;
         }
 
         private void Initialize()
@@ -138,6 +144,22 @@ namespace Blazored.Typeahead
             SearchText = "";
             IsShowingSuggestions = false;
             IsShowingMask = Value != null;
+        }
+
+        private IReadOnlyDictionary<string, object> CaptureCSSAttributes(IReadOnlyDictionary<string, object> additionalAttributes)
+        {
+            var capturedAttributes = additionalAttributes.ToDictionary(k => k.Key, v => v.Value);
+            if (capturedAttributes.ContainsKey("class"))
+            {
+                _classAttribute = (string)capturedAttributes["class"];
+                capturedAttributes.Remove("class");
+            }
+            if (capturedAttributes.ContainsKey("style"))
+            {
+                _styleAttribute = (string)capturedAttributes["style"];
+                capturedAttributes.Remove("style");
+            }
+            return capturedAttributes;
         }
 
         private async Task RemoveValue(TValue item)


### PR DESCRIPTION
see feature request: #227

### Behaviour
When the component is initialized the provided values for "class" and "style" are extracted from the uncaptured attributes parameter `AdditionalAttributes`. The values are then put into separate private fields:
- `string _classAttribute` for setting the class
- `string _styleAttribute` for setting styles
- `IReadOnlyDictionary<string, objec> _capturedAttributes` for the rest of the additional attributes
When no values for "class" or "style" are provided the component shows as default.
Otherwise the css styling from the outer div component will be overriden:
```html
<div class="blazored-typeahead @FieldCssClasses @_classAttribute" style="@_styleAttribute">
```

### Changes
- Added private fields for `_capturedAttributes`, `_classAttribute` and `_styleAttribute`
- Added method to extract "class" and "style" values from uncaptured attributes
- Set `_classAttribute` and `_styleAttribute` on the outer div of the component

### Example
Here is a quick example showing the component working together with input groups from Bootstrap 5.0:

**Default:**
```html
<div class="input-group">
    <div class="input-group-text">
        Person
    </div>
    <BlazoredTypeahead @bind-Value=PersonSelected 
                       SearchMethod=SearchPeople 
                       placeholder="Search by name...">
        <SelectedTemplate Context=person>
            @person?.Firstname @person?.Lastname
        </SelectedTemplate>
        <ResultTemplate Context=person>
            @person.Firstname @person.Lastname
        </ResultTemplate>
    </BlazoredTypeahead>
    <button class="btn btn-outline-secondary" type="button">Ok</button>
</div>
```
![grafik](https://user-images.githubusercontent.com/57634354/195061643-b50502eb-cec2-4f9f-a182-992736127014.png)

**Override style**
```html
<div class="input-group">
    <div class="input-group-text">
        Person
    </div>
    <BlazoredTypeahead @bind-Value=PersonSelected
                       class="form-control p-0"
                       style="color:red;"
                       SearchMethod=SearchPeople 
                       placeholder="Search by name...">
        <SelectedTemplate Context=person>
            @person?.Firstname @person?.Lastname
        </SelectedTemplate>
        <ResultTemplate Context=person>
            @person.Firstname @person.Lastname
        </ResultTemplate>
    </BlazoredTypeahead>
    <button class="btn btn-outline-secondary" type="button">Ok</button>
</div>
```
![grafik](https://user-images.githubusercontent.com/57634354/195062498-eb5f204b-89bc-422a-8f8f-4b2d482749cd.png)
![grafik](https://user-images.githubusercontent.com/57634354/195062667-1419170e-a479-4ba4-bad9-9654bdbc5cbb.png)

### Additional Information
This was just a quickly drawn together experiment because i wanted to use the component in a input-group, but since it seems to work well overall i thought i might propose this a feature.
The styling can be a bit fiddly to get right because it has to work together with all other styles used on the component. As you can see i had to set the default `form-control` padding to 0 to avoid double margins, but i guess it is up to the user to make this right.

All in all i think this is a good way to give the user enhance control over the design without interfering with the functionality of the component too much - and without any need to override the typehead css classes directly.